### PR TITLE
hashlib: fix build with old toolchains

### DIFF
--- a/lib/hashlib/CMakeLists.txt
+++ b/lib/hashlib/CMakeLists.txt
@@ -12,7 +12,6 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 
 set(HASHLIB_SRCS
     ${PROJECT_SOURCE_DIR}/src/crc32.cpp
-    ${PROJECT_SOURCE_DIR}/src/digest.cpp
     ${PROJECT_SOURCE_DIR}/src/keccak.cpp
     ${PROJECT_SOURCE_DIR}/src/md5.cpp
     ${PROJECT_SOURCE_DIR}/src/sha1.cpp


### PR DESCRIPTION
Drop `digest.cpp`, containing a `main` (code for a sample tool), which confuses old toolchains when the resulting hashlib library is used during linking.