### PR TITLE
make builds reproducible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,8 @@ execute_process(
 
 # get current date
 execute_process(
-        COMMAND env LC_ALL=C date -u "+%Y-%m-%d %H:%M:%S %Z"
+        COMMAND git log -1 --date=iso --format=format:%ad
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE BUILD_DATE
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
Don't set `BUILD_DATE` to configure time: use the authoring date of the git checkout current commit instead.